### PR TITLE
Refactor #84 admission results

### DIFF
--- a/admission/admission-web-adapter/src/main/kotlin/com/daegusw/apply/admission/web/adapter/AdmissionStatusController.kt
+++ b/admission/admission-web-adapter/src/main/kotlin/com/daegusw/apply/admission/web/adapter/AdmissionStatusController.kt
@@ -21,7 +21,7 @@ class AdmissionStatusController (
     fun findFirstAdmissionStatus(
         @AuthenticatedPrincipalId id: MemberId
     ): AdmissionStatusResponse{
-        return AdmissionStatusResponse(admissionStatusUseCase.findFirstStatus(id))
+        return AdmissionStatusResponse.fromFirst(admissionStatusUseCase.findFirstStatus(id))
     }
 
 
@@ -30,7 +30,7 @@ class AdmissionStatusController (
     fun findLastAdmissionStatus(
         @AuthenticatedPrincipalId id: MemberId
     ): AdmissionStatusResponse{
-        return AdmissionStatusResponse(admissionStatusUseCase.findLastStatus(id))
+        return AdmissionStatusResponse.fromLast(admissionStatusUseCase.findLastStatus(id))
     }
 
 }

--- a/admission/admission-web-adapter/src/main/kotlin/com/daegusw/apply/admission/web/adapter/response/AdmissionStatusResponse.kt
+++ b/admission/admission-web-adapter/src/main/kotlin/com/daegusw/apply/admission/web/adapter/response/AdmissionStatusResponse.kt
@@ -8,13 +8,19 @@ data class AdmissionStatusResponse(
     val applyType: ApplyType,
     val admissionStatus: String
 ) {
-    constructor(pair: Pair<FirstAdmissionStatus, ApplyType>) : this(
-        applyType = pair.second,
-        admissionStatus = pair.first.message
-    )
+    companion object {
+        fun fromFirst(pair: Pair<FirstAdmissionStatus, ApplyType>): AdmissionStatusResponse {
+            return AdmissionStatusResponse(
+                applyType = pair.second,
+                admissionStatus = pair.first.message
+            )
+        }
 
-    constructor(pair: Pair<LastAdmissionStatus, ApplyType>) : this(
-        applyType = pair.second,
-        admissionStatus = pair.first.message
-    )
+        fun fromLast(pair: Pair<LastAdmissionStatus, ApplyType>): AdmissionStatusResponse {
+            return AdmissionStatusResponse(
+                applyType = pair.second,
+                admissionStatus = pair.first.message
+            )
+        }
+    }
 }


### PR DESCRIPTION
## 연관된 이슈 번호

> #84 

## 개요

생성자를 오버로딩하는 과정에서 파라미터값을 JVM이 인식하지 못하여 빌드가 실패합니다.

## 작업 사항

AdmissionStatusResponse의 생성자를 정적 팩토리 메서드로 변경했습니다. 이전 생성자의 파라미터값을 JVM 판단하지 못하는 문제가 있어 빌드시 오류가 발생하였는데 그 문제를 해결하였습니다.

